### PR TITLE
Fixes clang compile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LUA_MODULE_DIR =    $(PREFIX)/share/lua/$(LUA_VERSION)
 LUA_BIN_DIR =       $(PREFIX)/bin
 
 CC= gcc
-AR= gcc
+AR= gcc -o
 
 ##### Platform overrides #####
 ##
@@ -100,7 +100,7 @@ all: $(TARGET)
 doc: manual.html performance.html
 
 $(TARGET): $(OBJS)
-	$(AR) $(LDFLAGS) $(CJSON_LDFLAGS) -o $@ $(OBJS)
+	$(AR) $(LDFLAGS) $(CJSON_LDFLAGS) $@ $(OBJS)
 
 install: $(TARGET)
 	mkdir -p $(DESTDIR)/$(LUA_CMODULE_DIR)


### PR DESCRIPTION
Clang's ar does not allow unknown options, such as -o.