### PR TITLE
Allow 16 digit precision

### DIFF
--- a/fpconv.c
+++ b/fpconv.c
@@ -154,7 +154,7 @@ static void set_number_format(char *fmt, int precision)
 {
     int d1, d2, i;
 
-    assert(1 <= precision && precision <= 14);
+    assert(1 <= precision && precision <= 16);
 
     /* Create printf format (%.14g) from precision */
     d1 = precision / 10;

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -308,7 +308,7 @@ static int json_cfg_encode_number_precision(lua_State *l)
 {
     json_config_t *cfg = json_arg_init(l, 1);
 
-    return json_integer_option(l, 1, &cfg->encode_number_precision, 1, 14);
+    return json_integer_option(l, 1, &cfg->encode_number_precision, 1, 16);
 }
 
 /* Configures JSON encoding buffer persistence */


### PR DESCRIPTION
test case
```lua
    local cjson = require "cjson"
    local double = 2 ^ 53
    print(cjson.encode(double))
    cjson.encode_number_precision(16)
    print(cjson.encode(double))
    print(string.format("%16.0f", cjson.decode("9007199254740992")))
```
--- out

```lua
  9.007199254741e+15
  9007199254740992
  9007199254740992
```