### PR TITLE
perf: using nil replace userdata: (nil) while decoding string which c...

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -1293,9 +1293,7 @@ static void json_process_value(lua_State *l, json_parse_t *json,
         json_parse_array_context(l, json);
         break;;
     case T_NULL:
-        /* In Lua, setting "t[k] = nil" will delete k from the table.
-         * Hence a NULL pointer lightuserdata object is used instead */
-        lua_pushlightuserdata(l, NULL);
+        lua_pushnil(l);
         break;;
     default:
         json_throw_parse_error(l, json, "value", token);


### PR DESCRIPTION
...ontains null
当前解析包含空字符串时会使用一个空指针替换，对不知道这个规则的人太不符合预期。是否还是保持原有的语义好一点呢？
~~~

/* In Lua, setting "t[k] = nil" will delete k from the table.
 * Hence a NULL pointer lightuserdata object is used instead */
// lua_pushlightuserdata(l, NULL);
~~~
更改后测试代码和输出结果如下，可能更符合预期
~~~
local tbl = {1, nil, "hello world"}
local encodeStr = json.encode(tbl)
print("encodeStr", encodeStr)
local decodeTbl = json.decode(encodeStr)
for k, v in pairs(decodeTbl) do
    print(k, v)
end
encodeStr = json.encode(decodeTbl)
print("encodeStr", encodeStr)
decodeTbl = json.decode(encodeStr)
for k, v in pairs(decodeTbl) do
    print(k, v)
end

local tbl = {a = "a", b = "b", c = "c"}
encodeStr = json.encode(tbl)
print("encodeStr", encodeStr)
decodeTbl = json.decode(encodeStr)
for k, v in pairs(decodeTbl) do
    print(k, v)
end

encodeStr = json.encode(decodeTbl)
print("encodeStr", encodeStr)
decodeTbl = json.decode(encodeStr)
for k, v in pairs(decodeTbl) do
    print(k, v)
end

输出：
encodeStr	[1,null,"hello world"]
1	1
3	hello world
encodeStr	[1,null,"hello world"]
1	1
3	hello world
encodeStr	{"c":"c","b":"b","a":"a"}
c	c
b	b
a	a
encodeStr	{"c":"c","b":"b","a":"a"}
c	c
b	b
a	a
~~~